### PR TITLE
NXCT-153: change binary store default configuration

### DIFF
--- a/nuxeo-apb/templates/nuxeo_dc.yml.j2
+++ b/nuxeo-apb/templates/nuxeo_dc.yml.j2
@@ -117,7 +117,7 @@ spec:
 {% endif %}
 {% if binaries_persistentVolume_enabled %}
         - name: NUXEO_BINARY_STORE
-          value: /var/lib/nuxeo/binaries
+          value: /var/lib/nuxeo/binaries/binaries
 {% endif %}
 {% if transientstore_persistentVolume_enabled %}
         - name: NUXEO_TRANSIENT_STORE


### PR DESCRIPTION
use a sub of the mount point instead of the mount point by itself (10.10 transient store)