### PR TITLE
Generic updates to the infrastructure as of 10/03/2020 on QA env.

### DIFF
--- a/nuxeo-arender-previewer-apb/apb.yml
+++ b/nuxeo-arender-previewer-apb/apb.yml
@@ -35,6 +35,11 @@ plans:
       type: number
       title: Timeout for the Nuxeo Client
       display_group: Client Nuxeo
+    - name: previewer_arender_max_tries
+      default: 5
+      type: number
+      title: Number of retries for ARender hmi to ask for a rendition call
+      display_group: Client Nuxeo
     - name: previewer_nuxeo_oauth_secret
       default: 'OAUTH2_SECRET'
       type: string
@@ -105,7 +110,7 @@ plans:
       title: Autoscaling Minimum replicas
       display_group: Autoscaling
     - name: arender_autoscaling_max
-      default: 10
+      default: 1
       type: number
       title: Autoscaling Maximum replicas
       display_group: Autoscaling

--- a/nuxeo-arender-previewer-apb/defaults/main.yml
+++ b/nuxeo-arender-previewer-apb/defaults/main.yml
@@ -20,12 +20,13 @@ previewer_image_pullPolicy: IfNotPresent
 previewer_resources: '{"limits": {"cpu": "2","memory": "4Gi"},"requests": {"cpu": "1","memory": "3Gi"}}'
 
 arender_autoscaling_min: 1
-arender_autoscaling_max: 10
+arender_autoscaling_max: 1
 arender_autoscaling_targetCPU: 80
 
 previewer_nuxeo_url: 'https://nuxeo.url/nuxeo'
 previewer_nuxeo_client_timeout: 60
 previewer_nuxeo_oauth_secret: 'OAUTH2_SECRET'
+previewer_arender_max_tries: 5
 
 arender_rendition_service_name: arender-pool-1
 arender_previewer_gw_timeout_in_seconds: 120s

--- a/nuxeo-arender-previewer-apb/templates/arender_previewer_dc.yml.j2
+++ b/nuxeo-arender-previewer-apb/templates/arender_previewer_dc.yml.j2
@@ -73,6 +73,8 @@ spec:
               value: {{ previewer_nuxeo_url }}
             - name: ARENDERSRV_NUXEO_CLIENT_TIMEOUT
               value: "{{ previewer_nuxeo_client_timeout }}"
+            - name: ARENDERSRV_ARENDER_SERVER_RENDITION_MAX_TRIES
+              value: "{{ previewer_arender_max_tries }}"
             - name: nuxeoArenderSecretEnv
               value: {{ previewer_nuxeo_oauth_secret }}
           resources:

--- a/nuxeo-arender-rendition-apb/apb.yml
+++ b/nuxeo-arender-rendition-apb/apb.yml
@@ -87,7 +87,7 @@ plans:
       display_type: textarea
       display_group: Container Specs
     - name: arender_jni_resources
-      default: '{"limits": {"cpu": "2","memory": "2Gi"},"requests": {"cpu": "2","memory": "2Gi"}}'
+      default: '{"limits": {"cpu": "2","memory": "6Gi"},"requests": {"cpu": "2","memory": "4Gi"}}'
       type: string
       title: JNI Pod resource requests and limits
       display_type: textarea
@@ -118,7 +118,7 @@ plans:
       display_group: ARender configuration
 
     - name: arender_rendition_conversion_timeout
-      default: 120
+      default: 240
       type: number
       title: Timeout for conversion
       display_group: ARender configuration

--- a/nuxeo-arender-rendition-apb/defaults/main.yaml
+++ b/nuxeo-arender-rendition-apb/defaults/main.yaml
@@ -42,7 +42,7 @@ arender_pdfbox_image_pullPolicy: IfNotPresent
 arender_broker_resources: '{"limits": {"cpu": "1","memory": "1Gi"},"requests": {"cpu": "1","memory": "1Gi"}}'
 arender_converter_resources: '{"limits": {"cpu": "1","memory": "6Gi"},"requests": {"cpu": "500m","memory": "4Gi"}}'
 arender_pdfbox_resources: '{"limits": {"cpu": "1","memory": "1Gi"},"requests": {"cpu": "1","memory": "1Gi"}}'
-arender_jni_resources: '{"limits": {"cpu": "2","memory": "2Gi"},"requests": {"cpu": "2","memory": "2Gi"}}'
+arender_jni_resources: '{"limits": {"cpu": "2","memory": "6Gi"},"requests": {"cpu": "2","memory": "4Gi"}}'
 arender_dfs_resources: '{"limits": {"cpu": "1","memory": "512M"},"requests": {"cpu": "1","memory": "512M"}}'
 
 arender_debug_pod: false
@@ -51,4 +51,4 @@ persistentVolume_storageClass: shared
 
 
 arender_rendition_imagemagick_options: '-quality,100,-density,72x72,-units,PixelsPerInch,-auto-orient,+repage'
-arender_rendition_conversion_timeout: 120
+arender_rendition_conversion_timeout: 240


### PR DESCRIPTION
1/ increase total RAM per pod for JNI (feedback from our QA team)
2/ Do not HPA the previewer (for now, set the HPA only to max 1 pod)
3/ increase total timeout for conversion of images in converter pod (allows for longer background conversion in ARender)
4/ Increase the retry on previewer side to absorb more exceptions from backend in case of unavailability of one service/method (as seen when JNI was too low on Memory, the pods would quickly become unavailable and connection refused would be sent)