### PR TITLE
NEV-334 : Update broker temporary storage volume

### DIFF
--- a/nuxeo-arender-rendition-apb/tasks/main.yaml
+++ b/nuxeo-arender-rendition-apb/tasks/main.yaml
@@ -21,7 +21,6 @@
     state: "{{ state }}"
     definition: "{{ lookup('template', 'arender_pvc.yml.j2') | from_yaml }}"
   loop:
-    - pvc_name: "{{ arender_rendition_broker_pvc_name }}"
     - pvc_name: "{{ arender_common_tmp_name }}"
     - pvc_name: "{{ arender_logs_pvc_name }}"
 

--- a/nuxeo-arender-rendition-apb/templates/arender_broker_dc.yml.j2
+++ b/nuxeo-arender-rendition-apb/templates/arender_broker_dc.yml.j2
@@ -117,7 +117,7 @@ spec:
 {% endif %}
           volumeMounts:
           - name: temp
-            mountPath: /arender/tmp
+            mountPath: /tmp
           - name: config
             mountPath: /arender/modules/config
           - name: logs
@@ -125,7 +125,7 @@ spec:
       volumes:
         - name: temp
           persistentVolumeClaim:
-            claimName: {{ arender_rendition_broker_pvc_name }}
+            claimName: {{ arender_common_tmp_name }}
         - name: config
           configMap:
             name: {{ arender_broker_log_configmap_name }}

--- a/nuxeo-arender-rendition-apb/templates/arender_debug_dc.yml.j2
+++ b/nuxeo-arender-rendition-apb/templates/arender_debug_dc.yml.j2
@@ -42,7 +42,7 @@ spec:
             claimName: "{{ arender_common_tmp_name }}"
         - name: broker-tmp
           persistentVolumeClaim:
-            claimName: "{{ arender_rendition_broker_pvc_name }}"
+            claimName: "{{ arender_common_tmp_name }}"
         - name: logs
           persistentVolumeClaim:
             claimName: "{{ arender_logs_pvc_name }}"

--- a/nuxeo-arender-rendition-apb/vars/main.yml
+++ b/nuxeo-arender-rendition-apb/vars/main.yml
@@ -65,7 +65,6 @@ arender_pdfbox_dc_name: "{{ name }}-pdfbox"
 
 arender_debug_dc_name: "{{ name }}-debug"
 
-arender_rendition_broker_pvc_name: "{{ name }}-tmp-broker"
 arender_common_tmp_name: "{{ name }}-tmp-common"
 arender_logs_pvc_name: "{{ name }}-logs"
 


### PR DESCRIPTION
For now, only moved the variable value instead of replacing each instance of _arender_rendition_broker_pvc_name_ to keep the changes to a minimum.
