### PR TITLE
NCO-8032 update busybox repo location

### DIFF
--- a/nuxeo-arender-previewer-apb/templates/arender_previewer_dc.yml.j2
+++ b/nuxeo-arender-previewer-apb/templates/arender_previewer_dc.yml.j2
@@ -112,7 +112,7 @@ spec:
 {% endif %}
       initContainers:
         - name: init-rendition-broker
-          image: busybox
+          image: public.ecr.aws/e0v6o2x1/busybox
           env:
             - name: BROKER_SERVICE_DNS
               valueFrom:

--- a/nuxeo-arender-rendition-apb/templates/arender_document_converter_dc.yml.j2
+++ b/nuxeo-arender-rendition-apb/templates/arender_document_converter_dc.yml.j2
@@ -37,7 +37,7 @@ spec:
 {% endif %}
       initContainers:
         - name: init-create-log-dir
-          image: busybox
+          image: public.ecr.aws/e0v6o2x1/busybox
           command: ['mkdir', '-m', '770', '-p', '/logs/arender-document-converter']
           volumeMounts:
           - name: logs

--- a/nuxeo-arender-rendition-apb/templates/arender_document_file_storage_dc.yml.j2
+++ b/nuxeo-arender-rendition-apb/templates/arender_document_file_storage_dc.yml.j2
@@ -37,7 +37,7 @@ spec:
 {% endif %}
       initContainers:
         - name: init-create-log-dir
-          image: busybox
+          image: public.ecr.aws/e0v6o2x1/busybox
           command: ['mkdir', '-m', '770', '-p', '/logs/arender-document-file-storage']
           volumeMounts:
           - name: logs

--- a/nuxeo-arender-rendition-apb/templates/arender_document_renderer_dc.yml.j2
+++ b/nuxeo-arender-rendition-apb/templates/arender_document_renderer_dc.yml.j2
@@ -47,7 +47,7 @@ spec:
 {% endif %}
       initContainers:
         - name: init-create-log-dir
-          image: busybox
+          image: public.ecr.aws/e0v6o2x1/busybox
           command: ['mkdir', '-m', '770', '-p', '/logs/arender-document-renderer']
           volumeMounts:
           - name: logs

--- a/nuxeo-arender-rendition-apb/templates/arender_document_service_broker_dc.yml.j2
+++ b/nuxeo-arender-rendition-apb/templates/arender_document_service_broker_dc.yml.j2
@@ -37,7 +37,7 @@ spec:
 {% endif %}
       initContainers:
         - name: init-create-log-dir
-          image: busybox
+          image: public.ecr.aws/e0v6o2x1/busybox
           command: ['mkdir', '-m', '770', '-p', '/logs/arender-document-service-broker']
           volumeMounts:
           - name: logs

--- a/nuxeo-arender-rendition-apb/templates/arender_document_text_handler_dc.yml.j2
+++ b/nuxeo-arender-rendition-apb/templates/arender_document_text_handler_dc.yml.j2
@@ -39,7 +39,7 @@ spec:
 {% endif %}
       initContainers:
         - name: init-create-log-dir
-          image: busybox
+          image: public.ecr.aws/e0v6o2x1/busybox
           command: ['mkdir', '-m', '770', '-p', '/logs/arender-document-text-handler']
           volumeMounts:
           - name: logs

--- a/nuxeo-elasticsearch-apb/apb.yml
+++ b/nuxeo-elasticsearch-apb/apb.yml
@@ -20,7 +20,7 @@ metadata:
   dependencies:
     - "docker.elastic.co/elasticsearch/elasticsearch:5.6.9"
     - "nuxeo/elasticsearch-sg:5.6.9"
-    - "docker.io/busybox"
+    - "public.ecr.aws/e0v6o2x1/busybox"
   providerDisplayName: "Nuxeo"
   documentationUrl: >-
     https://github.com/nuxeo-sandbox/nuxeo-apb-catalog/nuxeo-elasticsearch-apb/

--- a/nuxeo-elasticsearch-apb/templates/statefulset.yml.j2
+++ b/nuxeo-elasticsearch-apb/templates/statefulset.yml.j2
@@ -46,7 +46,7 @@ spec:
       # see https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
       # and https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration-memory.html#mlockall
       - name: "sysctl"
-        image: "busybox"
+        image: "public.ecr.aws/e0v6o2x1/busybox"
         imagePullPolicy: "Always"
         command: ["sysctl", "-w", "vm.max_map_count=262144"]
         securityContext:

--- a/nuxeo-mongodb-apb/apb-dev.sh
+++ b/nuxeo-mongodb-apb/apb-dev.sh
@@ -14,7 +14,7 @@ function runAPB {
     # Create stub-asb-binding deployment to facilitate asb credential binding in 'docker run' environment
     local PHRASE=$(head /dev/urandom | tr -dc a-z0-9 | head -c 5 ; echo '')
     local DEPLOYMENT_NAME=stub-asb-binding-$PHRASE
-    kubectl run $DEPLOYMENT_NAME --image=busybox --namespace=$POD_NAMESPACE
+    kubectl run $DEPLOYMENT_NAME --image=public.ecr.aws/e0v6o2x1/busybox --namespace=$POD_NAMESPACE
     local POD_NAME=$(kubectl get po --namespace=$POD_NAMESPACE \
         --selector="run=${DEPLOYMENT_NAME}" --no-headers --output='custom-columns=NAME:.metadata.name')
 

--- a/nuxeo-mongodb-apb/apb.yml
+++ b/nuxeo-mongodb-apb/apb.yml
@@ -17,7 +17,7 @@ metadata:
     security and a replicaset deployment secured with TLS encryption, X509
     membership authentication, and SCRAM client authentication
   dependencies:
-    - "docker.io/busybox:latest"
+    - "public.ecr.aws/e0v6o2x1/busybox"
     - "k8s.gcr.io/mongodb-install:0.6"
     - "docker.io/mongo"
   providerDisplayName: "Nuxeo"

--- a/nuxeo-mongodb-apb/roles/nuxeo-mongodb-apb-provisioning/templates/statefulset.yml.j2
+++ b/nuxeo-mongodb-apb/roles/nuxeo-mongodb-apb-provisioning/templates/statefulset.yml.j2
@@ -33,7 +33,7 @@ spec:
 {% endif %}
       initContainers:
         - name: copy-config
-          image: busybox
+          image: public.ecr.aws/e0v6o2x1/busybox
           command:
             - "sh"
           args:


### PR DESCRIPTION
changes

nuxeo-arender-previewer-apb/templates/arender_previewer_dc.yml.j2:          image: public.ecr.aws/e0v6o2x1/busybox
nuxeo-arender-rendition-apb/templates/arender_document_converter_dc.yml.j2:          image: public.ecr.aws/e0v6o2x1/busybox
nuxeo-arender-rendition-apb/templates/arender_document_renderer_dc.yml.j2:          image: public.ecr.aws/e0v6o2x1/busybox
nuxeo-arender-rendition-apb/templates/arender_document_service_broker_dc.yml.j2:          image: public.ecr.aws/e0v6o2x1/busybox
nuxeo-arender-rendition-apb/templates/arender_document_text_handler_dc.yml.j2:          image: public.ecr.aws/e0v6o2x1/busybox
nuxeo-arender-rendition-apb/templates/arender_document_file_storage_dc.yml.j2:          image: public.ecr.aws/e0v6o2x1/busybox
nuxeo-elasticsearch-apb/templates/statefulset.yml.j2:        image: "public.ecr.aws/e0v6o2x1/busybox"
nuxeo-elasticsearch-apb/apb.yml:    - "public.ecr.aws/e0v6o2x1/busybox"
nuxeo-mongodb-apb/roles/nuxeo-mongodb-apb-provisioning/templates/statefulset.yml.j2:          image: public.ecr.aws/e0v6o2x1/busybox
nuxeo-mongodb-apb/apb.yml:    - "public.ecr.aws/e0v6o2x1/busybox"
nuxeo-mongodb-apb/apb-dev.sh:    kubectl run $DEPLOYMENT_NAME --image=public.ecr.aws/e0v6o2x1/busybox --namespace=$POD_NAMESPACE