### PR TITLE
NXCT-598: Remove the DFS from deployment for upcoming NEV 10.6.0 release

### DIFF
--- a/nuxeo-arender-rendition-apb/tasks/default.yml
+++ b/nuxeo-arender-rendition-apb/tasks/default.yml
@@ -28,6 +28,7 @@
       file: arender_document_converter_logback.xml
     - name: "{{ arender_document_file_storage_log_configmap_name }}"
       file: arender_document_file_storage_logback.xml
+      apply: "{{ arender_rendition_image_version | regex_replace('\\.NX.*','') is version('4.4.2', '<') }}"
     - name: "{{ arender_document_renderer_log_configmap_name }}"
       file: arender_document_renderer_logback.xml
     - name: "{{ arender_document_text_handler_log_configmap_name }}"
@@ -52,7 +53,9 @@
     - name: arender_document_converter_dc.yml.j2
     - name: arender_document_converter_service.yml.j2
     - name: arender_document_file_storage_dc.yml.j2
+      apply: "{{ arender_rendition_image_version | regex_replace('\\.NX.*','') is version('4.4.2', '<') }}"
     - name: arender_document_file_storage_service.yml.j2
+      apply: "{{ arender_rendition_image_version | regex_replace('\\.NX.*','') is version('4.4.2', '<') }}"
     - name: arender_document_renderer_dc.yml.j2
     - name: arender_document_renderer_service.yml.j2
     - name: arender_document_text_handler_dc.yml.j2
@@ -73,6 +76,7 @@
       target_dc: "{{ arender_document_converter_dc_name }}"
     - name: document-file-storage
       target_dc: "{{ arender_document_file_storage_dc_name }}"
+      apply: "{{ arender_rendition_image_version | regex_replace('\\.NX.*','') is version('4.4.2', '<') }}"
     - name: document-text-handler
       target_dc: "{{ arender_document_text_handler_dc_name }}"
     - name: document-renderer

--- a/nuxeo-arender-rendition-apb/templates/arender_document_service_broker_dc.yml.j2
+++ b/nuxeo-arender-rendition-apb/templates/arender_document_service_broker_dc.yml.j2
@@ -83,8 +83,10 @@ spec:
           env:
           - name: DSB_KUBEPROVIDER_KUBE.HOSTS_{{ arender_document_converter_service_name }}
             value: "{{ arender_document_converter_internal_port }}"
+{% if arender_rendition_image_version | regex_replace('\.NX.*','') is version('4.4.2', '<') %}
           - name: DSB_KUBEPROVIDER_KUBE.HOSTS_{{ arender_document_file_storage_service_name }}
             value: "{{ arender_document_file_storage_internal_port }}"
+{% endif %}
           - name: DSB_KUBEPROVIDER_KUBE.HOSTS_{{ arender_document_renderer_service_name }}
             value: "{{ arender_document_renderer_internal_port }}"
           - name: DSB_KUBEPROVIDER_KUBE.HOSTS_{{ arender_document_text_handler_service_name }}

--- a/nuxeo-arender-rendition-apb/templates/arender_hazelcast_service.yml.j2
+++ b/nuxeo-arender-rendition-apb/templates/arender_hazelcast_service.yml.j2
@@ -18,4 +18,8 @@ spec:
       port: {{ arender_hazelcast_internal_port }}
   selector:
     app: {{ app_name }}
+{% if arender_rendition_image_version | regex_replace('\.NX.*','') is version('4.4.2', '>=') %}
+    role: rendition-document-service-broker
+{% else %}
     role: rendition-document-file-storage
+{% endif %}


### PR DESCRIPTION
Successfully tested on a 10.5, the APB is backward compatible.

Waiting the next version to test the DFS removal.