### PR TITLE
NXCT-801 NXCT-796: Update ARender APB for upcoming versions + collect logs for DD

### DIFF
--- a/nuxeo-arender-previewer-apb/defaults/main.yml
+++ b/nuxeo-arender-previewer-apb/defaults/main.yml
@@ -23,6 +23,8 @@ arender_previewer_monitoring_kibana_service: arender-monitor-kibana
 arender_previewer_monitoring_datadog_enabled: false
 arender_previewer_monitoring_datadog_key: ''
 
+arender_previewer_nginx_proxy_enabled: false
+
 arender_previewer_ha: false
 
 previewer_image_pullPolicy: IfNotPresent

--- a/nuxeo-arender-previewer-apb/defaults/main.yml
+++ b/nuxeo-arender-previewer-apb/defaults/main.yml
@@ -13,8 +13,11 @@ apb_name: nuxeo-arender-previewer-apb
 namespace: "{{ lookup('env','NAMESPACE') | default('hello-world', true) }}"
 
 testing: false
-arender_previewer_image: docker-registry.default.svc:5000/common-infra/arender-previewer
-arender_previewer_image_version: "10.3.5"
+arender_previewer_image_registry: "docker-registry.default.svc:5000/common-infra"
+arender_previewer_image_legacy: true
+arender_previewer_image_name: "{{ 'arender-previewer' if arender_previewer_image_legacy else 'nuxeo-arender-ui' }}"
+arender_previewer_image: "{{ arender_previewer_image_registry }}/{{ arender_previewer_image_name }}"
+arender_previewer_image_version: "{{ '10.6.8' if arender_previewer_image_legacy else '1.0.0' }}"
 
 arender_previewer_monitoring_enabled: false
 arender_previewer_monitoring_es_service: arender-monitor-elasticsearch

--- a/nuxeo-arender-previewer-apb/tasks/main.yml
+++ b/nuxeo-arender-previewer-apb/tasks/main.yml
@@ -27,6 +27,7 @@
     - name: arender_previewer_hazelcast_service.yml.j2
       apply: "{{ arender_previewer_ha }}"
     - name: arender_previewer_nginx_config.yml.j2
+      apply: "{{ arender_previewer_nginx_proxy_enabled }}"
     - name: arender_previewer_datadog_agent_config.yml.j2
       apply: "{{ arender_previewer_monitoring_datadog_enabled }}"
     - name: arender_previewer_datadog_agent_secret.yml.j2

--- a/nuxeo-arender-previewer-apb/templates/arender_previewer_dc.yml.j2
+++ b/nuxeo-arender-previewer-apb/templates/arender_previewer_dc.yml.j2
@@ -161,6 +161,7 @@ spec:
             readOnly: true
             mountPath: "/conf.d/tomcat.d"
 {% endif %}
+{% if arender_previewer_nginx_proxy_enabled %}
         - name: nginx-proxy
           image: twalter/openshift-nginx
           volumeMounts:
@@ -175,6 +176,7 @@ spec:
           - name: http-endpoint
             containerPort: 8081
             protocol: TCP
+{% endif %}
 
 {% if use_pull_secret %}
       imagePullSecrets:
@@ -216,6 +218,7 @@ spec:
           configMap:
             defaultMode: 493
             name: {{ arender_previewer_pre_stop_scripts_configmap_name }}
+{% if arender_previewer_nginx_proxy_enabled %}
         - name: nginx-conf
           configMap:
             name: {{ nginx_configmap_name }}
@@ -223,6 +226,7 @@ spec:
           emptyDir: {}
         - name: nginx-tmp
           emptyDir: {}
+{% endif %}
 {% if arender_previewer_monitoring_datadog_enabled %}
         - name: datadog-agent-conf
           configMap:

--- a/nuxeo-arender-previewer-apb/templates/arender_previewer_dc.yml.j2
+++ b/nuxeo-arender-previewer-apb/templates/arender_previewer_dc.yml.j2
@@ -41,20 +41,6 @@ spec:
 {{ previewer_securityContext | from_yaml | to_nice_yaml(indent=2) | indent(8, true) }}
 {% endif %}
       containers:
-        - name: nginx-proxy
-          image: twalter/openshift-nginx
-          volumeMounts:
-          - name: nginx-conf
-            readOnly: true
-            mountPath: "/etc/nginx/"
-          - name: nginx-cache
-            mountPath: "/var/cache/nginx"
-          - name: nginx-tmp
-            mountPath: "/var/tmp"
-          ports:
-          - name: http-endpoint
-            containerPort: 8081
-            protocol: TCP
         - image: {{ arender_previewer_image }}:{{ arender_previewer_image_version }}
           imagePullPolicy: {{ previewer_image_pullPolicy }}
           lifecycle:
@@ -175,6 +161,20 @@ spec:
             readOnly: true
             mountPath: "/conf.d/tomcat.d"
 {% endif %}
+        - name: nginx-proxy
+          image: twalter/openshift-nginx
+          volumeMounts:
+          - name: nginx-conf
+            readOnly: true
+            mountPath: "/etc/nginx/"
+          - name: nginx-cache
+            mountPath: "/var/cache/nginx"
+          - name: nginx-tmp
+            mountPath: "/var/tmp"
+          ports:
+          - name: http-endpoint
+            containerPort: 8081
+            protocol: TCP
 
 {% if use_pull_secret %}
       imagePullSecrets:

--- a/nuxeo-arender-previewer-apb/templates/arender_previewer_dc.yml.j2
+++ b/nuxeo-arender-previewer-apb/templates/arender_previewer_dc.yml.j2
@@ -110,6 +110,12 @@ spec:
 {% if arender_previewer_monitoring_datadog_enabled %}
             - name: TOMCAT_JMX_PORT
               value: "{{ monitoring_jmx_tomcat_port }}"
+{% if datadog_tomcat_access_logs_enabled %}
+            - name: TOMCAT_ACCESS_LOG_DIRECTORY
+              value: "/var/log/arender-ui"
+            - name: TOMCAT_ACCESS_LOG_MAX_DAYS
+              value: "2"
+{% endif %}
 {% endif %}
 {% if arender_previewer_monitoring_enabled %}
             - name: ARENDERSRV_ARENDER_SERVER_PERF_ES_USE
@@ -131,6 +137,8 @@ spec:
 {{ previewer_resources | from_yaml | to_nice_yaml(indent=2) | indent(12, true) }}
 {% endif %}
           volumeMounts:
+          - name: datadog-logs
+            mountPath: "/var/log/arender-ui"
           - name: log-config
             mountPath: /usr/local/tomcat/log-config
           - name: logs
@@ -152,6 +160,8 @@ spec:
                 secretKeyRef:
                   name: {{ datadog_agent_secret_name }}
                   key: api_key
+            - name: DD_LOGS_ENABLED
+              value: "true"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -160,6 +170,9 @@ spec:
           - name: datadog-agent-conf
             readOnly: true
             mountPath: "/conf.d/tomcat.d"
+          - name: datadog-logs
+            readOnly: true
+            mountPath: "/var/log/arender-ui"
 {% endif %}
 {% if arender_previewer_nginx_proxy_enabled %}
         - name: nginx-proxy
@@ -231,6 +244,8 @@ spec:
         - name: datadog-agent-conf
           configMap:
             name: {{ datadog_agent_configmap_name }}
+        - name: datadog-logs
+          emptyDir: {}
 {% endif %}
       terminationGracePeriodSeconds: 60
   triggers:

--- a/nuxeo-arender-previewer-apb/templates/arender_previewer_log_config.yml.j2
+++ b/nuxeo-arender-previewer-apb/templates/arender_previewer_log_config.yml.j2
@@ -11,6 +11,6 @@ metadata:
   namespace: {{ namespace }}
 data:
   log4j.xml: |
-    {{ lookup('file', '../files/log4j.xml') | indent(4) }}
+    {{ lookup('template', './log4j.xml.j2') | indent(4) }}
   logging.properties: |
-    {{ lookup('file', '../files/logging.properties') | indent(4) }}
+    {{ lookup('template', './logging.properties.j2') | indent(4) }}

--- a/nuxeo-arender-previewer-apb/templates/arender_previewer_service.yml.j2
+++ b/nuxeo-arender-previewer-apb/templates/arender_previewer_service.yml.j2
@@ -15,7 +15,11 @@ spec:
   - name: web
     port: 80
     protocol: TCP
+{% if arender_previewer_nginx_proxy_enabled %}
     targetPort: 8081
+{% else %}
+    targetPort: 8080
+{% endif %}
   selector:
     app: {{ app_name }}
     role: arender-previewer

--- a/nuxeo-arender-previewer-apb/templates/datadog-agent.yml.j2
+++ b/nuxeo-arender-previewer-apb/templates/datadog-agent.yml.j2
@@ -277,3 +277,17 @@ logs:
       - app_name:{{ name }}
       - log_type:tomcat_catalina_log
       - namespace:{{ namespace }}
+  - type: file
+    path: /var/log/arender-ui/*-perf.log
+    source: nev-ui-perf
+    service: {{ name }}
+    sourcecategory: sourcecode
+    log_processing_rules:
+      - type: multi_line
+        name: new_log_start_with_start_then_date
+        pattern: Start=\d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12][0-9]|3[01]) (0[1-9]|1[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]),\d{1,3}
+    tags:
+      - app_name:{{ name }}
+      - log_type:tomcat_perf_log
+      - namespace:{{ namespace }}
+

--- a/nuxeo-arender-previewer-apb/templates/datadog-agent.yml.j2
+++ b/nuxeo-arender-previewer-apb/templates/datadog-agent.yml.j2
@@ -238,8 +238,8 @@ instances:
 ##
 ## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/
 #
-{% if datadog_tomcat_access_logs_enabled %}
 logs:
+{% if datadog_tomcat_access_logs_enabled %}
   - type: file
     path: /var/log/arender-ui/*_access_log.*.txt
     source: nev-ui-access
@@ -250,3 +250,30 @@ logs:
       - log_type:tomcat_access_log
       - namespace:{{ namespace }}
 {% endif %}
+  - type: file
+    path: /var/log/arender-ui/*-app.log
+    source: nev-ui
+    service: {{ name }}
+    sourcecategory: sourcecode
+    log_processing_rules:
+      - type: multi_line
+        name: new_log_start_with_date
+        pattern: \d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12][0-9]|3[01]) (0[1-9]|1[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]),\d{1,3}
+    tags:
+      - app_name:{{ name }}
+      - log_type:tomcat_application_log
+      - namespace:{{ namespace }}
+  - type: file
+    path: /var/log/arender-ui/catalina.log
+    source: nev-ui
+    service: {{ name }}
+    sourcecategory: sourcecode
+    start_position: beginning
+    log_processing_rules:
+      - type: multi_line
+        name: new_log_start_with_date
+        pattern: \d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12][0-9]|3[01]) (0[1-9]|1[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]),\d{1,3}
+    tags:
+      - app_name:{{ name }}
+      - log_type:tomcat_catalina_log
+      - namespace:{{ namespace }}

--- a/nuxeo-arender-previewer-apb/templates/datadog-agent.yml.j2
+++ b/nuxeo-arender-previewer-apb/templates/datadog-agent.yml.j2
@@ -286,6 +286,9 @@ logs:
       - type: multi_line
         name: new_log_start_with_start_then_date
         pattern: Start=\d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12][0-9]|3[01]) (0[1-9]|1[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]),\d{1,3}
+      - type: exclude_at_match
+        name: exclude_get_rendition_targets
+        pattern: Method=ServletDocumentService.getRenditionTargets
     tags:
       - app_name:{{ name }}
       - log_type:tomcat_perf_log

--- a/nuxeo-arender-previewer-apb/templates/datadog-agent.yml.j2
+++ b/nuxeo-arender-previewer-apb/templates/datadog-agent.yml.j2
@@ -238,8 +238,15 @@ instances:
 ##
 ## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/
 #
-# logs:
-#   - type: file
-#     path: /var/log/tomcat/*.log
-#     source: tomcat
-#     service: <SERVICE_NAME>
+{% if datadog_tomcat_access_logs_enabled %}
+logs:
+  - type: file
+    path: /var/log/arender-ui/*_access_log.*.txt
+    source: nev-ui-access
+    service: {{ name }}
+    sourcecategory: http_web_access
+    tags:
+      - app_name:{{ name }}
+      - log_type:tomcat_access_log
+      - namespace:{{ namespace }}
+{% endif %}

--- a/nuxeo-arender-previewer-apb/templates/log4j.xml.j2
+++ b/nuxeo-arender-previewer-apb/templates/log4j.xml.j2
@@ -5,7 +5,11 @@
   <!-- A time/date based rolling appender -->
   <appender name="FILE" class="org.apache.log4j.DailyRollingFileAppender">
     <errorHandler class="org.apache.log4j.helpers.OnlyOnceErrorHandler" />
+{% if arender_previewer_monitoring_datadog_enabled %}
+    <param name="File" value="/var/log/arender-ui/${POD_NAME}-app.log" />
+{% else %}
     <param name="File" value="/usr/local/tomcat/logs/${POD_NAME}.log" />
+{% endif %}
     <param name="Append" value="true" />
     <!-- Rollover at midnight every day -->
     <param name="DatePattern" value="'.'yyyy-MM-dd" />

--- a/nuxeo-arender-previewer-apb/templates/log4j.xml.j2
+++ b/nuxeo-arender-previewer-apb/templates/log4j.xml.j2
@@ -21,7 +21,11 @@
   <!-- A time/date based rolling appender -->
   <appender name="FILE-PERF" class="org.apache.log4j.DailyRollingFileAppender">
     <errorHandler class="org.apache.log4j.helpers.OnlyOnceErrorHandler" />
+{% if arender_previewer_monitoring_datadog_enabled %}
+    <param name="File" value="/var/log/arender-ui/${POD_NAME}-perf.log" />
+{% else %}
     <param name="File" value="/usr/local/tomcat/logs/${POD_NAME}-perf.log" />
+{% endif %}
     <param name="Append" value="true" />
     <!-- Rollover at midnight every day -->
     <param name="DatePattern" value="'.'yyyy-MM-dd" />

--- a/nuxeo-arender-previewer-apb/templates/logging.properties.j2
+++ b/nuxeo-arender-previewer-apb/templates/logging.properties.j2
@@ -9,10 +9,16 @@ java.util.logging.SimpleFormatter.format = %1$tF %1$tT,%1$tL %4$s [catalina] [%3
 # Describes specific configuration info for Handlers.
 ############################################################
 
-1catalina.org.apache.juli.AsyncFileHandler.level = FINE
+1catalina.org.apache.juli.AsyncFileHandler.level = INFO
+{% if arender_previewer_monitoring_datadog_enabled %}
+1catalina.org.apache.juli.AsyncFileHandler.directory = /var/log/arender-ui
+1catalina.org.apache.juli.AsyncFileHandler.prefix = catalina
+1catalina.org.apache.juli.AsyncFileHandler.rotatable = false
+{% else %}
 1catalina.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
 1catalina.org.apache.juli.AsyncFileHandler.prefix = catalina.${POD_NAME}.
 1catalina.org.apache.juli.AsyncFileHandler.maxDays = 30
+{% endif %}
 1catalina.org.apache.juli.AsyncFileHandler.formatter = java.util.logging.SimpleFormatter
 1catalina.org.apache.juli.AsyncFileHandler.encoding = UTF-8
 

--- a/nuxeo-arender-previewer-apb/vars/main.yml
+++ b/nuxeo-arender-previewer-apb/vars/main.yml
@@ -54,6 +54,8 @@ arender_previewer_java_opts: "-XX:NativeMemoryTracking=summary -DPOD_NAME=${POD_
 monitoring_jmx_tomcat_port: "9000"
 datadog_agent_configmap_name: "{{ name }}-datadog-agent-config"
 datadog_agent_secret_name: "{{ name }}-datadog-agent-api-key"
+# disable for legacy as image doesn't support it in 10.6.8
+datadog_tomcat_access_logs_enabled: "{{ false if arender_previewer_image_legacy else arender_previewer_monitoring_datadog_enabled }}"
 
 monitoring_es_binding_name: "{{ name }}-monitor-es-binding"
 monitoring_es_binding_secret_name:  "{{ name }}-monitor-es-binding"

--- a/nuxeo-arender-rendition-apb/defaults/main.yaml
+++ b/nuxeo-arender-rendition-apb/defaults/main.yaml
@@ -19,12 +19,13 @@ arender_tmp_storage_size: 500Gi
 arender_log_storage_size: 150Gi
 
 arender_rendition_image_registry: "docker-registry.default.svc:5000/common-infra"
-arender_rendition_image_version: "4.0.9.NX1.0"
-arender_rendition_image_document_service_broker: arender-document-service-broker
-arender_rendition_image_document_converter: arender-document-converter
+arender_rendition_image_legacy: true
+arender_rendition_image_version: "{{ '4.4.2.NX1.6' if arender_rendition_image_legacy else '1.0.0' }}"
+arender_rendition_image_document_service_broker: "{{ 'arender-document-service-broker' if arender_rendition_image_legacy else 'nuxeo-arender-document-service-broker' }}"
+arender_rendition_image_document_converter: "{{ 'arender-document-converter' if arender_rendition_image_legacy else 'nuxeo-arender-document-converter' }}"
 arender_rendition_image_document_file_storage: arender-document-file-storage
-arender_rendition_image_document_renderer: arender-document-renderer
-arender_rendition_image_document_text_handler: arender-document-text-handler
+arender_rendition_image_document_renderer: "{{ 'arender-document-renderer' if arender_rendition_image_legacy else 'nuxeo-arender-document-renderer' }}"
+arender_rendition_image_document_text_handler: "{{ 'arender-document-text-handler' if arender_rendition_image_legacy else 'nuxeo-arender-document-text-handler' }}"
 
 arender_rendition_monitoring_enabled: false
 arender_rendition_monitoring_es_service: arender-monitor-elasticsearch


### PR DESCRIPTION
NXCT-801 is an APB update for the upcoming versions which comes with a renaming and a versioning change.
NXCT-796 is Datadog agent configuration + APB adaptation to collect ARender Previewer logs to send them to DD

Collected logs contained:
- Tomcat Access logs (only available for the 1.0.0 version for now)
- Tomcat Application logs
- ARender performance logs

There're also 3 logs processor on DD and [one dashboard](https://app.datadoghq.com/dashboard/iku-xeh-hpm/nev-system-dashboard) on NXIO account.